### PR TITLE
use atom-workspace

### DIFF
--- a/keymaps/ti-alloy-related.cson
+++ b/keymaps/ti-alloy-related.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-r': 'ti-alloy-related:openRelated'


### PR DESCRIPTION
~~~
keymaps/ti-alloy-related.cson
Use the `atom-workspace` tag instead of the `workspace` class.
~~~
got a deprecation warning for workspace; should be atom-workspace now